### PR TITLE
Handle secondary signing files

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ GitHub action for generating and publishing release metadata using hc-releases.
 | metadata-file      | Release hcl metadata-file (will use project-dir as the base dir)                                        | No       | .release/release-metadata.hcl                            | string      |
 | changelog          | Add changelog URL to the release metadata                                                               | No       | 'true'		    										 | string      |
 | artifact-dir       | Directory containing release artifacts                                                                  | No       | 'dist'                                                   | string      |
-| build-artifacts    | Build artifact file extensions - space separated list. These files will get added to the build metadata | No       | 'zip'                                                    | string      |
+| build-artifacts    | (Deprecated) Build artifact file extensions - space separated list. These files will get added to the build metadata | No       | 'zip'                                                    | string      |
 
 ### Example Usage
 

--- a/action.yml
+++ b/action.yml
@@ -38,7 +38,7 @@ runs:
       - uses: hashicorp/action-setup-bob@v1
         with:
           github-token: "${{ inputs.private-tools-token }}"
-          version: "0.0.22-beta4"
+          version: "0.0.22"
       - name: Setup hc-releases
         uses: hashicorp/actions-setup-hc-releases@v1
         with:

--- a/action.yml
+++ b/action.yml
@@ -29,7 +29,7 @@ inputs:
     required: false
     default: 'dist'
   build-artifacts:
-    description: 'Build artifact file extensions - space separated list. These files will get added to the build metadata.'
+    description: '(Deprecated) Build artifact file extensions - space separated list. These files will get added to the build metadata.'
     required: false
     default: 'zip'
 runs:

--- a/scripts/generate-metadata.sh
+++ b/scripts/generate-metadata.sh
@@ -6,16 +6,6 @@ curl -SsL https://github.com/kvz/json2hcl/releases/download/v0.0.6/json2hcl_v0.0
 
 json2hcl -reverse < "$METADATA_FILE" > meta.json
 
-mkdir build-artifacts
-
-for EXTENSION in $BUILD_ARTIFACTS
-do
-	cp "$ARTIFACT_DIR"/*."$EXTENSION" build-artifacts/
-	echo "$ARTIFACT_DIR"/*."$EXTENSION"
-done
-
-ls build-artifacts
-
 if [ "$CHANGELOG" == 'true' ]; then
 	changelogurl="https://github.com/$REPO/blob/v$VERSION/CHANGELOG.md"
 else
@@ -23,5 +13,5 @@ else
 fi
 
 bob generate-release-metadata -metadata-file "meta.json" \
--in-dir "build-artifacts" -out-file "release-metadata-final.json" \
+-in-dir "$ARTIFACT_DIR" -out-file "release-metadata-final.json" \
 -changelog-url "$changelogurl" -version "$VERSION"


### PR DESCRIPTION
This PR is part of [RDX-492](https://hashicorp.atlassian.net/jira/software/projects/RDX/boards/305/backlog?selectedIssue=RDX-429&text=429)
This PR requires a release of bob with https://github.com/hashicorp/bob/pull/62

Bob now handles all release artifact types, and will conditionally create a
secondary signing file if not present on disk. This necessitates passing the
entire artifact directory to bob.

This PR also deprecates the `build-artifacts` actions.yml configuration as it
is no longer needed with the changes to `bob`.

Signed-off-by: Scott Macfarlane <smacfarlane@hashicorp.com>