### PR TITLE
Add optional product-repo input

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,6 +17,7 @@ GitHub action for generating and publishing release metadata using hc-releases.
 | changelog          | Add changelog URL to the release metadata                                                               | No       | 'true'		    										 | string      |
 | artifact-dir       | Directory containing release artifacts                                                                  | No       | 'dist'                                                   | string      |
 | build-artifacts    | (Deprecated) Build artifact file extensions - space separated list. These files will get added to the build metadata | No       | 'zip'                                                    | string      |
+| product-repo       | Org-qualified product repo if not the same as the repo running the action, e.g. "hashicorp/vault".      | No       | ''                                                       | string      |
 
 ### Example Usage
 

--- a/action.yml
+++ b/action.yml
@@ -32,6 +32,9 @@ inputs:
     description: '(Deprecated) Build artifact file extensions - space separated list. These files will get added to the build metadata.'
     required: false
     default: 'zip'
+  product-repo:
+    description: 'Org-qualified product repo if not the same as the repo running the action, e.g. "hashicorp/vault"'
+    required: false
 runs:
   using: "composite"
   steps:
@@ -52,6 +55,7 @@ runs:
           METADATA_FILE: ${{ inputs.metadata-file }}
           PRODUCT_NAME: ${{ inputs.product-name }}
           REPO: ${{ github.repository }}
+          PRODUCT_REPO: ${{ inputs.product-repo }}
           ARTIFACT_DIR: ${{ inputs.artifact-dir }}
           BUILD_ARTIFACTS: ${{ inputs.build-artifacts }}
         run: |

--- a/scripts/generate-metadata.sh
+++ b/scripts/generate-metadata.sh
@@ -15,7 +15,7 @@ json2hcl -version
 json2hcl -reverse < "$METADATA_FILE" > meta.json
 
 if [ "$CHANGELOG" == 'true' ]; then
-	changelogurl="https://github.com/$REPO/blob/v$VERSION/CHANGELOG.md"
+	changelogurl="https://github.com/${PRODUCT_REPO:-REPO}/blob/v$VERSION/CHANGELOG.md"
 else
 	changelogurl=""
 fi


### PR DESCRIPTION
We have some cases where the repo running this action is not the same as the product's repo being released, so we get the wrong changelog URL:

```shell-session
$ curl --silent https://api.releases.hashicorp.com/v1/releases/vault-plugin-secrets-kv/0.15.0 | jq -r '.url_changelog'
https://github.com/hashicorp/vault-plugin-release/blob/v0.15.0/CHANGELOG.md
```

Here's an example test-run of the action with product-repo set using my fork: https://github.com/hashicorp/vault-plugin-release/actions/runs/5359043775/jobs/9722118607#step:22:29 (Note that there are two builds, one from today and one from a month ago. Obviously, only the one from today is fixed, although the repo doesn't actually have a changelog, so while the link has the correct repo, it returns 404)

There are a lot of ways to solve for this, but this approach seemed fairly simple and minimally invasive. LMK any thoughts!